### PR TITLE
Feature power

### DIFF
--- a/Microwave.App/Program.cs
+++ b/Microwave.App/Program.cs
@@ -20,6 +20,8 @@ namespace Microwave.App
 
             PowerTube powerTube = new PowerTube(output);
 
+            powerTube.SetMaxPowerInWatts(700);
+
             Light light = new Light(output);
 
             Microwave.Classes.Boundary.Timer timer = new Timer();

--- a/Microwave.Classes/Boundary/PowerTube.cs
+++ b/Microwave.Classes/Boundary/PowerTube.cs
@@ -11,6 +11,8 @@ namespace Microwave.Classes.Boundary
 
         private bool IsOn = false;
 
+        private int MaxPowerInWatts { get; set; }
+
         public PowerTube(IOutput output)
         {
             myOutput = output;
@@ -18,9 +20,9 @@ namespace Microwave.Classes.Boundary
 
         public void TurnOn(int power)
         {
-            if (power < 1 || 700 < power)
+            if (power < 1 || MaxPowerInWatts < power)
             {
-                throw new ArgumentOutOfRangeException("power", power, "Must be between 1 and 700 (incl.)");
+                throw new ArgumentOutOfRangeException("power", power, $"Must be between 1 and {MaxPowerInWatts}  (incl.)");
             }
 
             if (IsOn)
@@ -41,5 +43,12 @@ namespace Microwave.Classes.Boundary
 
             IsOn = false;
         }
+
+        public int GetMaxPowerInWatts()
+        {
+            return MaxPowerInWatts;
+        }
+
+       
     }
 }

--- a/Microwave.Classes/Boundary/PowerTube.cs
+++ b/Microwave.Classes/Boundary/PowerTube.cs
@@ -11,7 +11,7 @@ namespace Microwave.Classes.Boundary
 
         private bool IsOn = false;
 
-        private int MaxPowerInWatts { get; set; }
+        private int MaxPowerInWatts { get; set; } = 700;
 
         public PowerTube(IOutput output)
         {
@@ -49,6 +49,12 @@ namespace Microwave.Classes.Boundary
             return MaxPowerInWatts;
         }
 
+        public void SetMaxPowerInWatts(int maxPowerInWatts)
+        {
+            if (maxPowerInWatts < 1 || 2400 < maxPowerInWatts)
+                throw new ArgumentOutOfRangeException("power", MaxPowerInWatts, $"Must be between 1 and 2400  (incl.)");
+            MaxPowerInWatts = maxPowerInWatts;
+        }
        
     }
 }

--- a/Microwave.Classes/Boundary/PowerTube.cs
+++ b/Microwave.Classes/Boundary/PowerTube.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using Microwave.Classes.Interfaces;
 
+//power feature
+
 namespace Microwave.Classes.Boundary
 {
     public class PowerTube : IPowerTube

--- a/Microwave.Classes/Controllers/CookController.cs
+++ b/Microwave.Classes/Controllers/CookController.cs
@@ -69,5 +69,9 @@ namespace Microwave.Classes.Controllers
                 myDisplay.ShowTime(remaining / 60, remaining % 60);
             }
         }
+        
+        public int GetMaxPowerInWatts(){
+            return myPowerTube.GetMaxPowerInWatts();
+        }
     }
 }

--- a/Microwave.Classes/Controllers/UserInterface.cs
+++ b/Microwave.Classes/Controllers/UserInterface.cs
@@ -56,7 +56,7 @@ namespace Microwave.Classes.Controllers
                     myState = States.SETPOWER;
                     break;
                 case States.SETPOWER:
-                    powerLevel = (powerLevel >= 700 ? 50 : powerLevel+50);
+                    powerLevel = (powerLevel >= myCooker.GetMaxPowerInWatts() ? 50 : powerLevel+50);
                     myDisplay.ShowPower(powerLevel);
                     break;
             }

--- a/Microwave.Classes/Controllers/UserInterface.cs
+++ b/Microwave.Classes/Controllers/UserInterface.cs
@@ -56,7 +56,7 @@ namespace Microwave.Classes.Controllers
                     myState = States.SETPOWER;
                     break;
                 case States.SETPOWER:
-                    powerLevel = (powerLevel >= myCooker.GetMaxPowerInWatts() ? 50 : powerLevel+50);
+                    powerLevel = (powerLevel < myCooker.GetMaxPowerInWatts() ? powerLevel+50 : 50);
                     myDisplay.ShowPower(powerLevel);
                     break;
             }

--- a/Microwave.Classes/Interfaces/ICookController.cs
+++ b/Microwave.Classes/Interfaces/ICookController.cs
@@ -10,5 +10,7 @@ namespace Microwave.Classes.Interfaces
     {
         void StartCooking(int power, int time);
         void Stop();
+
+        int GetMaxPowerInWatts();
     }
 }

--- a/Microwave.Classes/Interfaces/IPowerTube.cs
+++ b/Microwave.Classes/Interfaces/IPowerTube.cs
@@ -13,5 +13,6 @@ namespace Microwave.Classes.Interfaces
         void TurnOff();
 
         int GetMaxPowerInWatts();
+        void SetMaxPowerInWatts(int maxPowerInWatts);
     }
 }

--- a/Microwave.Classes/Interfaces/IPowerTube.cs
+++ b/Microwave.Classes/Interfaces/IPowerTube.cs
@@ -11,5 +11,7 @@ namespace Microwave.Classes.Interfaces
         void TurnOn(int power);
 
         void TurnOff();
+
+        int GetMaxPowerInWatts();
     }
 }

--- a/Microwave.Test.Integration/TDStep2.cs
+++ b/Microwave.Test.Integration/TDStep2.cs
@@ -35,6 +35,8 @@ namespace Microwave.Test.Integration
             startCancelButton = new Button();
 
             powerTube = Substitute.For<IPowerTube>();
+            powerTube.SetMaxPowerInWatts(1000);
+            powerTube.GetMaxPowerInWatts().Returns(1000);
             timer = Substitute.For<ITimer>();
             output = Substitute.For<IOutput>();
 
@@ -184,7 +186,7 @@ namespace Microwave.Test.Integration
             powerButton.Press();
             timeButton.Press();
             startCancelButton.Press();
-
+            
             // Cooking has started
             // Can be verified by powertube
             powerTube.Received().TurnOn(100);

--- a/Microwave.Test.Unit/CookControllerTest.cs
+++ b/Microwave.Test.Unit/CookControllerTest.cs
@@ -82,6 +82,15 @@ namespace Microwave.Test.Unit
 
             powerTube.Received().TurnOff();
         }
+        
+        [TestCase(100)]
+        public void Cooker_TjeckMaxPower(int maxPower)
+        {
+            powerTube.GetMaxPowerInWatts().Returns(maxPower);
+
+            Assert.That(uut.GetMaxPowerInWatts(), Is.EqualTo(maxPower));
+
+        }
 
     }
 }

--- a/Microwave.Test.Unit/PowerTubeTest.cs
+++ b/Microwave.Test.Unit/PowerTubeTest.cs
@@ -61,5 +61,35 @@ namespace Microwave.Test.Unit
             uut.TurnOn(50);
             Assert.Throws<System.ApplicationException>(() => uut.TurnOn(60));
         }
+
+        [Test]
+        public void GetMaxPowerInWatts_DefaultValue_CorrectValue()
+        {
+            Assert.That(uut.GetMaxPowerInWatts(), Is.EqualTo(700));
+        }
+        
+
+        [TestCase(1)]
+        [TestCase(500)]
+        [TestCase(1000)]
+        [TestCase(2399)]
+        [TestCase(2400)]
+        public void Get_Set_MaxPowerInWatts_NewValue_CorrectValue(int SetPower)
+        {
+            uut.SetMaxPowerInWatts(SetPower);
+            Assert.That(uut.GetMaxPowerInWatts(), Is.EqualTo(SetPower));
+        }
+        
+        [TestCase(-5)]
+        [TestCase(-1)]
+        [TestCase(0)]
+        [TestCase(2401)]
+        [TestCase(2750)]
+        public void SetMaxPowerInWatts_OutOfRangeValue_ThrowsException(int SetPower)
+        {
+            Assert.Throws<System.ArgumentOutOfRangeException>(() => uut.SetMaxPowerInWatts(SetPower));
+        }
+
+       
     }
 }

--- a/Microwave.Test.Unit/UserInterfaceTest.cs
+++ b/Microwave.Test.Unit/UserInterfaceTest.cs
@@ -32,7 +32,8 @@ namespace Microwave.Test.Unit
             light = Substitute.For<ILight>();
             display = Substitute.For<IDisplay>();
             cooker = Substitute.For<ICookController>();
-
+            cooker.GetMaxPowerInWatts().Returns(1000);
+        
             uut = new UserInterface(
                 powerButton, timeButton, startCancelButton,
                 door,
@@ -75,25 +76,33 @@ namespace Microwave.Test.Unit
         [Test]
         public void Ready_2PowerButton_PowerIs100()
         {
+            cooker.GetMaxPowerInWatts().Returns(1000);
+            // This test that uut has subscribed to power button, and works correctly
             powerButton.Pressed += Raise.EventWith(this, EventArgs.Empty);
             powerButton.Pressed += Raise.EventWith(this, EventArgs.Empty);
             display.Received(1).ShowPower(Arg.Is<int>(100));
         }
 
-        [Test]
-        public void Ready_14PowerButton_PowerIs700()
+        [TestCase(500)]
+        [TestCase(700)]
+        [TestCase(1000)]
+        public void Ready_xPowerButton_PowerIs500_700_1000(int maxpower)
         {
-            for (int i = 1; i <= 14; i++)
+            cooker.GetMaxPowerInWatts().Returns(maxpower);
+            for (int i = 1; i <= (maxpower/50); i++)
             {
                 powerButton.Pressed += Raise.EventWith(this, EventArgs.Empty);
             }
-            display.Received(1).ShowPower(Arg.Is<int>(700));
+            display.Received(1).ShowPower(Arg.Is<int>(maxpower));
         }
 
-        [Test]
-        public void Ready_15PowerButton_PowerIs50Again()
+        [TestCase(500)]
+        [TestCase(700)]
+        [TestCase(1000)]
+        public void Ready_15PowerButton_PowerIs50Again(int maxpower)
         {
-            for (int i = 1; i <= 15; i++)
+            cooker.GetMaxPowerInWatts().Returns(maxpower);
+            for (int i = 1; i <= (maxpower/50)+1; i++)
             {
                 powerButton.Pressed += Raise.EventWith(this, EventArgs.Empty);
             }
@@ -196,6 +205,7 @@ namespace Microwave.Test.Unit
         [Test]
         public void Ready_PowerAndTime_CookerIsCalledCorrectly()
         {
+           
             powerButton.Pressed += Raise.EventWith(this, EventArgs.Empty);
             // Now in SetPower
             powerButton.Pressed += Raise.EventWith(this, EventArgs.Empty);
@@ -210,10 +220,16 @@ namespace Microwave.Test.Unit
             cooker.Received(1).StartCooking(100, 120);
         }
 
-        [Test]
-        public void Ready_FullPower_CookerIsCalledCorrectly()
+        [TestCase(500)]
+        [TestCase(600)]
+        [TestCase(700)]
+        [TestCase(800)]
+        public void Ready_FullPower_CookerIsCalledCorrectly(int MaxP)
         {
-            for (int i = 50; i <= 700; i += 50)
+            int maxTestPower = MaxP;
+            cooker.GetMaxPowerInWatts().Returns(maxTestPower);
+            
+            for (int i = 50; i <= maxTestPower; i += 50)
             {
                 powerButton.Pressed += Raise.EventWith(this, EventArgs.Empty);
             }
@@ -224,7 +240,7 @@ namespace Microwave.Test.Unit
             // Should call with correct values
             startCancelButton.Pressed += Raise.EventWith(this, EventArgs.Empty);
 
-            cooker.Received(1).StartCooking(700, 60);
+            cooker.Received(1).StartCooking(MaxP, 60);
 
         }
 


### PR DESCRIPTION
### Wanted to Add MaxPower imput. 
This is done by adding a property in powerTube - _MaxPowerInWatts_
this removes the hardcoded "700" power. 

The userInterface and the controller uses this value. And this can be retrived troug the PowerTubeInterface and then again from the cookcontrollers interface to the User interface 

**Userinterface Sequnce:** 
mycooker.GetMaxPowerInWatts -> myPowerTube.GetMaxPowerInWatts -> return MaxPowerInWatts

**In test** we have created new tests in PowerTubeTest 
And we have alteret 5 test in Intergration test to include multible MaxPowers
We have also added a thing to the setup. 
In UserInterface test we have created a returnvalue from the cooker as this now is a new dependensie. 


